### PR TITLE
Fix undefined method `helper_method`

### DIFF
--- a/lib/gtm_on_rails/engine.rb
+++ b/lib/gtm_on_rails/engine.rb
@@ -14,16 +14,16 @@ module GtmOnRails
   def self.config
     @config ||= GtmOnRails::Config.new
   end
- 
+
   def self.configure(&block)
     yield(config) if block_given?
   end
-  
+
   class Engine < ::Rails::Engine
     isolate_namespace GtmOnRails
 
     initializer 'gtm_on_rails.action_controller_extension' do
-      ActiveSupport.on_load :action_controller do
+      ActiveSupport.on_load :action_controller_base do
         include GtmOnRails::Controllers::InitializeDataLayer
       end
     end


### PR DESCRIPTION
When gtm_on_rails is used with the gem using ActionController::API,
undefined method `helper_method` error occurs.

initialize_data_layer.rb:12:in `block in <module:InitializeDataLayer>': undefined method `helper_method' for ActionController::API:Class (NoMethodError)